### PR TITLE
feat(): add time remaining to render panel

### DIFF
--- a/src/view/components/panels/RenderPanel.js
+++ b/src/view/components/panels/RenderPanel.js
@@ -25,7 +25,13 @@ export default function RenderPanel({ onClose }) {
   const fps = elapsedTime > 0 ? frame / elapsedTime : 0;
   const text = finished ? 'Close' : 'Cancel';
   const style = { width: `${progress}%` };
-  const totalTime = frame ? (frames * elapsedTime) / frame : null;
+
+  const totalTime = frame > 0 ? (frames * elapsedTime) / frame : null;
+  const estimatedTotalTimeThreshold = 0.1;
+  const estimatedTotalTime =
+    frame > 0 && frame / frames >= 0.15
+      ? estimatedTotalTimeThreshold && formatTime(totalTime)
+      : '--:-';
 
   function handleButtonClick() {
     dispatch(stopRender());
@@ -72,10 +78,7 @@ export default function RenderPanel({ onClose }) {
       <div className={styles.stats}>
         <div className={styles.row}>
           <Stat label="Progress" value={`${~~progress}%`} />
-          <Stat
-            label="Elapsed Time"
-            value={`${formatTime(elapsedTime)} / ${totalTime && formatTime(totalTime)}`}
-          />
+          <Stat label="Elapsed Time" value={`${formatTime(elapsedTime)} / ${estimatedTotalTime}`} />
           <Stat label="Frames" value={`${~~frame} / ${~~frames}`} />
           <Stat label="FPS" value={fps.toFixed(1)} />
           <Button text={text} onClick={handleButtonClick} />

--- a/src/view/components/panels/RenderPanel.js
+++ b/src/view/components/panels/RenderPanel.js
@@ -25,7 +25,7 @@ export default function RenderPanel({ onClose }) {
   const fps = elapsedTime > 0 ? frame / elapsedTime : 0;
   const text = finished ? 'Close' : 'Cancel';
   const style = { width: `${progress}%` };
-  const timeRemaining = (frames * elapsedTime) / frame - elapsedTime;
+  const totalTime = frame ? (frames * elapsedTime) / frame : null;
 
   function handleButtonClick() {
     dispatch(stopRender());
@@ -72,8 +72,10 @@ export default function RenderPanel({ onClose }) {
       <div className={styles.stats}>
         <div className={styles.row}>
           <Stat label="Progress" value={`${~~progress}%`} />
-          <Stat label="Elapsed Time" value={formatTime(elapsedTime)} />
-          <Stat label="Time Remaining" value={formatTime(timeRemaining)} />
+          <Stat
+            label="Elapsed Time"
+            value={`${formatTime(elapsedTime)} / ${totalTime && formatTime(totalTime)}`}
+          />
           <Stat label="Frames" value={`${~~frame} / ${~~frames}`} />
           <Stat label="FPS" value={fps.toFixed(1)} />
           <Button text={text} onClick={handleButtonClick} />

--- a/src/view/components/panels/RenderPanel.js
+++ b/src/view/components/panels/RenderPanel.js
@@ -25,6 +25,7 @@ export default function RenderPanel({ onClose }) {
   const fps = elapsedTime > 0 ? frame / elapsedTime : 0;
   const text = finished ? 'Close' : 'Cancel';
   const style = { width: `${progress}%` };
+  const timeRemaining = (frames * elapsedTime) / frame - elapsedTime;
 
   function handleButtonClick() {
     dispatch(stopRender());
@@ -72,6 +73,7 @@ export default function RenderPanel({ onClose }) {
         <div className={styles.row}>
           <Stat label="Progress" value={`${~~progress}%`} />
           <Stat label="Elapsed Time" value={formatTime(elapsedTime)} />
+          <Stat label="Time Remaining" value={formatTime(timeRemaining)} />
           <Stat label="Frames" value={`${~~frame} / ${~~frames}`} />
           <Stat label="FPS" value={fps.toFixed(1)} />
           <Button text={text} onClick={handleButtonClick} />


### PR DESCRIPTION
This adds approximate the time remaining for the render. This assumes that the rate of render is linear, which might not be true. Certain frames render more quickly or slowly than others, so without writing extensive timing logic, this approximation is getting the job done.

<img width="881" alt="Screen Shot 2020-10-09 at 8 27 40 AM" src="https://user-images.githubusercontent.com/1041792/95602133-54e1ce00-0a09-11eb-8bdc-69b14ad9c1f5.png">


Alternatively, instead of having two fields for "Elapsed Time" and "Time Remaining", we could consider displaying them in a different format: `0:30 / 2:45` 

***

Links Issue #7 