### PR TITLE
Fix object.spec.js test + add support for debugging in vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ Thumbs.db
 
 # Environment
 .idea
-.vscode
 .env
 *.iml
 *.bat

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug: yarn build",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": [ "run", "build" ],
+    },
+    {
+      "name": "Debug: yarn dev",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": [ "run", "dev" ],
+    },
+    {
+      "name": "Debug: yarn test",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": [ "run", "test" ],
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,6 +24,45 @@
       "cwd": "${workspaceFolder}",
       "runtimeExecutable": "yarn",
       "runtimeArgs": [ "run", "test" ],
+    },
+    {
+      "name": "React: DevServer",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "env": { "PORT": "3001" },
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": [ "run", "dev" ],
+    },
+    {
+      "name": "Electron: Main",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "protocol": "inspector",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
+      "runtimeArgs": [ "--remote-debugging-port=9223", "." ],
+      "windows": {
+        "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
+      }
+    },
+    {
+      "name": "Electron: Renderer",
+      "type": "chrome",
+      "request": "attach",
+      "port": 9223,
+      "webRoot": "${workspaceFolder}",
+      "timeout": 15000
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Astrofox: Debug",
+      "configurations": [
+        "React: DevServer",
+        "Electron: Main",
+        "Electron: Renderer",
+      ]
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Debug: yarn build",
+      "name": "Build: yarn build",
       "type": "node",
       "request": "launch",
       "cwd": "${workspaceFolder}",
@@ -10,7 +10,7 @@
       "runtimeArgs": [ "run", "build" ],
     },
     {
-      "name": "Debug: yarn dev",
+      "name": "Build: yarn dev",
       "type": "node",
       "request": "launch",
       "cwd": "${workspaceFolder}",
@@ -18,7 +18,7 @@
       "runtimeArgs": [ "run", "dev" ],
     },
     {
-      "name": "Debug: yarn test",
+      "name": "Build: yarn test",
       "type": "node",
       "request": "launch",
       "cwd": "${workspaceFolder}",

--- a/__tests__/utils/object.spec.js
+++ b/__tests__/utils/object.spec.js
@@ -1,15 +1,21 @@
 import { updateExistingProps } from 'utils/object';
+import cloneDeep from 'lodash/cloneDeep';
 
 describe('updateExistingProps works properly', () => {
   test('oldProps !== newProps', () => {
-    const oldProps = { speed: "100" };
-    const newProps = { speed: "200"};
-    expect(updateExistingProps(oldProps, newProps)).toBeTruthy();
+    const oldProps = { speed: "100", theta: 75, acceleration: "2m/s", undefined: null };
+    const newProps = { speed: "200", direction: 75, acceleration: 4.2, undefined: undefined };
+    const result = updateExistingProps(oldProps, newProps);
+    expect(result).toBeTruthy();
+    expect(oldProps).toStrictEqual({ speed: "200", theta: 75, acceleration: 4.2, undefined: undefined });
   });
 
   test('oldProps === newProps', () => {
-    const oldProps = { speed: "100" };
-    const newProps = { speed: "100" };
-    expect(updateExistingProps(oldProps, newProps)).toBeFalsy();
+    const oldProps = { speed: "100", theta: 75, acceleration: "2m/s", undefined: undefined };
+    const newProps = { speed: "100", theta: 75, direction: 75, acceleration: "2m/s", undefined: undefined };
+    const oldPropsDup = cloneDeep(oldProps);
+    const result = updateExistingProps(oldProps, newProps);
+    expect(result).toBeFalsy();
+    expect(oldProps).toStrictEqual(oldPropsDup);
   });
 });

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -1,9 +1,10 @@
 export function updateExistingProps(obj, props) {
   let changed = false;
 
-  for (const [key, value] of Object.entries(props)) {
+  for (let keys = Object.keys(props), len = keys.length, i = 0; i < len; ++i) {
+    const key = keys[i];
     if (obj[key] !== undefined) {
-      obj[key] = value;
+      obj[key] = props[key];
       changed = true;
     }
   }

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -3,9 +3,12 @@ export function updateExistingProps(obj, props) {
 
   for (let keys = Object.keys(props), len = keys.length, i = 0; i < len; ++i) {
     const key = keys[i];
-    if (obj[key] !== undefined) {
-      obj[key] = props[key];
-      changed = true;
+    if (key in obj) {
+      const value = props[key];
+      if (value !== obj[key]) {
+        obj[key] = value;
+        changed = true;
+      }
     }
   }
 


### PR DESCRIPTION
### Fixed Jest Test: object.spec.js#updateExistingProps 


### Added support for debugging via vscode.  Every file in this project can now:
* Have breakpoints set in them by clicking the line number in the vscode gutter.
* Be stepped through
* Have variables and scope inspected at any arbitrary point 

This includes webpack and babel configs as well as jest test cases. 

