### PR TITLE
fix: corrects loadUrl call by calling loadData with arrayBuffer

### DIFF
--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -34,7 +34,7 @@ export default class Audio {
   // Loads a url via AJAX
   async loadUrl(url) {
     const response = await fetch(url);
-    return this.loadData(response);
+    return this.loadData(response.arrayBuffer());
   }
 
   // Decodes an ArrayBuffer into an AudioBuffer


### PR DESCRIPTION
loadData from loadUrl was incorrectly called with fetch response rather than result of fetch responses' arrayBuffer